### PR TITLE
Added 'monsters (no longer) have trouble pinpointing your location' message

### DIFF
--- a/src/do_wear.c
+++ b/src/do_wear.c
@@ -842,6 +842,11 @@ dragon_armor_handling(
             ESlow_digestion &= ~W_ARM;
         }
         break;
+    case SHIMMERING_DRAGON_SCALES:
+    case SHIMMERING_DRAGON_SCALE_MAIL:
+        You_feel("that monsters%s have difficulty pinpointing your location.",
+                 puton ? "" : " no longer");
+        break;
     default:
         break;
     }


### PR DESCRIPTION
I looked at the toggle_displacement function used for the cloaks but the only thing it does, other than the message, is identify displacement cloaks which isn't necessary for the dragon scales.

I added this to the code that adds and removes DSM secondary abilities.